### PR TITLE
Give the ranges enum a type

### DIFF
--- a/src/Kaleidoscope-Ranges.h
+++ b/src/Kaleidoscope-Ranges.h
@@ -21,7 +21,7 @@
 namespace kaleidoscope {
 namespace ranges {
 
-enum {
+enum : uint16_t {
   FIRST       = 0xc000,
   KALEIDOSCOPE_FIRST = FIRST,
   OS_FIRST,


### PR DESCRIPTION
This restricts the data type of the enum to uint16_t, so if anyone ever adds enough values to it to overflow the 16 bits that are available in the Key structure, even if they do it without an assignment (e.g. `TOO_BIG_ENUM = 0x10000`), it will result in a compilation error instead of runtime errors.