### PR TITLE
License update, copyright assignment & CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Developer Certificate of Origin
+
+All contributions must include acceptance of the DCO:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## Sign your work
+
+To accept the DCO, please add this line to each commit message with your name
+and email address (`git commit -s` will do this for you):
+
+    Signed-off-by: Jane Example <jane@example.com>

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Kaleidoscope-Ranges
 version=0.0.0
 author=Gergely Nagy
-maintainer=Gergely Nagy <kaleidoscope@gergo.csillger.hu>
+maintainer=Gergely Nagy <algernon@keyboard.io>
 sentence=Common ranges, used by a number of Kaleidoscope plugins.
 paragraph=...
 category=Communication

--- a/src/Kaleidoscope-Ranges.h
+++ b/src/Kaleidoscope-Ranges.h
@@ -2,18 +2,17 @@
  * Kaleidoscope-Ranges -- Common ranges, used by a number of Kaleidoscope plugins.
  * Copyright (C) 2016, 2017  Gergely Nagy
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once

--- a/src/Kaleidoscope-Ranges.h
+++ b/src/Kaleidoscope-Ranges.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Ranges -- Common ranges, used by a number of Kaleidoscope plugins.
- * Copyright (C) 2016, 2017  Gergely Nagy
+ * Copyright (C) 2016, 2017  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
This changes the license to GPLv3-only, assigns my copyright to Keyboard.io Inc,
and adds a CONTRIBUTING.md.